### PR TITLE
Fix issues #5 and #6: expand default black_list and add IPYNB_ANSWER codeblock

### DIFF
--- a/pact/README.md
+++ b/pact/README.md
@@ -150,6 +150,27 @@ code or markdown that you want to keep hidden from students.
 To exclude an entire cell from the student version of the `ipynb` file, simply add the following
 keyword anywhere within the cell: `ANSWER_KEY_CELL`.
 
+#### Answer placeholders in markdown cells
+
+For markdown Q cells where an instructor has drafted a written answer, wrap the
+answer text with `IPYNB_ANSWER_START` / `IPYNB_ANSWER_END`. In the student version,
+the entire region (including the trigger lines) is replaced with a green
+`YOUR ANSWER HERE` placeholder.
+
+```markdown
+**Q1.** Why is X important?
+
+IPYNB_ANSWER_START
+
+[instructor's draft answer goes here]
+
+IPYNB_ANSWER_END
+```
+
+Renders in the student version as:
+
+> <span style='color:green;'> YOUR ANSWER HERE </span>
+
 
 ### Special Files 📁
 

--- a/pact/convert/codeblocks.py
+++ b/pact/convert/codeblocks.py
@@ -54,6 +54,22 @@ KEY_ONLY = CodeBlockType(
 
 
 # =====
+# IPYNB Answer block: This codeblock is used to wrap instructor-written answer-key
+# text inside a Jupyter notebook markdown cell. In the student version, the
+# wrapped region is replaced with a "YOUR ANSWER HERE" placeholder.
+ipynb_answer_replacement_str = """
+<span style='color:green;'> YOUR ANSWER HERE </span>
+"""
+
+IPYNB_ANSWER = CodeBlockType(
+    name="IPYNB Answer Block",
+    start_trigger_str="IPYNB_ANSWER_START",
+    end_trigger_str="IPYNB_ANSWER_END",
+    replacement_str=ipynb_answer_replacement_str,
+)
+
+
+# =====
 # Feel free to implement additional codeblocks as needed here!
 
 

--- a/pact/convert/utils/prime_converter.py
+++ b/pact/convert/utils/prime_converter.py
@@ -26,10 +26,57 @@ OPTIONS_FILE_NAME = "options.pact"
 
 # Patterns always excluded from STUDENT_VERSION/ output, even without a
 # per-assignment black_list.pact. Per-assignment black lists extend these.
+#
+# Patterns are Python regexes matched against the full path with re.search.
+# Directory-style entries use (^|/)name($|/) so they only match the directory
+# itself or descendants — not unrelated files that happen to contain the name
+# as a substring (e.g. `venv` should not match `prevention.py`).
 DEFAULT_BLACK_LIST = [
+    # OS noise
     r"\.DS_Store$",
-    r"__pycache__",
+    r"(^|/)Thumbs\.db$",
+    r"(^|/)desktop\.ini$",
+    # Jupyter checkpoints (top-level or nested)
     r"\.ipynb_checkpoints",
+    # Compiled Python / bytecode / native extensions
+    r"__pycache__",
+    r"\.py[cod]$",
+    r"\$py\.class$",
+    r"\.so$",
+    # Python virtual environments
+    r"(^|/)\.venv($|/)",
+    r"(^|/)venv($|/)",
+    r"(^|/)env($|/)",
+    r"(^|/)ENV($|/)",
+    # Build / packaging artifacts
+    r"(^|/)build($|/)",
+    r"(^|/)dist($|/)",
+    r"(^|/)wheels($|/)",
+    r"(^|/)eggs($|/)",
+    r"(^|/)\.eggs($|/)",
+    r"\.egg-info($|/)",
+    r"\.egg$",
+    r"(^|/)MANIFEST$",
+    # IDE / editor metadata
+    r"(^|/)\.idea($|/)",
+    r"(^|/)\.vscode($|/)",
+    r"\.swp$",
+    # Type checker / linter caches
+    r"(^|/)\.mypy_cache($|/)",
+    r"(^|/)\.pytype($|/)",
+    r"(^|/)\.ruff_cache($|/)",
+    r"(^|/)\.?dmypy\.json$",
+    # Test / coverage artifacts
+    r"(^|/)\.pytest_cache($|/)",
+    r"(^|/)\.tox($|/)",
+    r"(^|/)\.nox($|/)",
+    r"(^|/)\.coverage(\..*)?$",
+    r"(^|/)coverage\.xml$",
+    r"(^|/)htmlcov($|/)",
+    r"(^|/)\.hypothesis($|/)",
+    # pip artifacts
+    r"(^|/)pip-log\.txt$",
+    r"(^|/)pip-delete-this-directory\.txt$",
 ]
 
 
@@ -207,11 +254,6 @@ class PrimeConverter:
 
         # If the file/folder is in the generated location, don't convert it
         if self.master_generation_location == source_file_or_folder:
-            return False
-
-        # Ignore compiled python bytecode (.pyc); __pycache__ itself is covered
-        # by DEFAULT_BLACK_LIST below.
-        if ".pyc" in source_file_or_folder:
             return False
 
         # Ignore special files

--- a/tests/integration_tests/test_prime_converter.py
+++ b/tests/integration_tests/test_prime_converter.py
@@ -172,6 +172,83 @@ class TestConversionFilter:
         # Unrelated file still passes
         assert converter.conversion_filter("/path/main.py") is True
 
+    def test_filters_virtual_environments(self, converter):
+        """Common Python virtual environment directory names are filtered."""
+        assert converter.conversion_filter("/proj/.venv") is False
+        assert converter.conversion_filter("/proj/venv") is False
+        assert converter.conversion_filter("/proj/env") is False
+        assert converter.conversion_filter("/proj/ENV") is False
+        assert converter.conversion_filter("/proj/venv/lib/site-packages/x.py") is False
+        # Substring collisions are NOT filtered
+        assert converter.conversion_filter("/proj/prevention.py") is True
+        assert converter.conversion_filter("/proj/environment.yml") is True
+
+    def test_filters_build_artifacts(self, converter):
+        """Build / packaging artifacts are filtered."""
+        assert converter.conversion_filter("/proj/build") is False
+        assert converter.conversion_filter("/proj/dist") is False
+        assert converter.conversion_filter("/proj/wheels") is False
+        assert converter.conversion_filter("/proj/eggs") is False
+        assert converter.conversion_filter("/proj/.eggs") is False
+        assert converter.conversion_filter("/proj/pact.egg-info") is False
+        assert converter.conversion_filter("/proj/pact.egg-info/PKG-INFO") is False
+        assert converter.conversion_filter("/proj/pact.egg") is False
+        assert converter.conversion_filter("/proj/MANIFEST") is False
+
+    def test_filters_compiled_python(self, converter):
+        """Compiled Python and native-extension files are filtered."""
+        assert converter.conversion_filter("/proj/module.pyc") is False
+        assert converter.conversion_filter("/proj/module.pyo") is False
+        assert converter.conversion_filter("/proj/module.pyd") is False
+        assert converter.conversion_filter("/proj/Hello$py.class") is False
+        assert converter.conversion_filter("/proj/_ext.so") is False
+
+    def test_filters_ide_metadata(self, converter):
+        """IDE / editor metadata is filtered."""
+        assert converter.conversion_filter("/proj/.idea") is False
+        assert converter.conversion_filter("/proj/.idea/workspace.xml") is False
+        assert converter.conversion_filter("/proj/.vscode") is False
+        assert converter.conversion_filter("/proj/.vscode/settings.json") is False
+        assert converter.conversion_filter("/proj/main.py.swp") is False
+
+    def test_filters_linter_and_typecheck_caches(self, converter):
+        """mypy/pytype/ruff cache directories and dmypy state are filtered."""
+        assert converter.conversion_filter("/proj/.mypy_cache") is False
+        assert converter.conversion_filter("/proj/.mypy_cache/3.10/x") is False
+        assert converter.conversion_filter("/proj/.pytype") is False
+        assert converter.conversion_filter("/proj/.ruff_cache") is False
+        assert converter.conversion_filter("/proj/.dmypy.json") is False
+        assert converter.conversion_filter("/proj/dmypy.json") is False
+
+    def test_filters_test_and_coverage_artifacts(self, converter):
+        """Test runner and coverage artifacts are filtered."""
+        assert converter.conversion_filter("/proj/.pytest_cache") is False
+        assert converter.conversion_filter("/proj/.tox") is False
+        assert converter.conversion_filter("/proj/.nox") is False
+        assert converter.conversion_filter("/proj/.coverage") is False
+        assert converter.conversion_filter("/proj/.coverage.host.1234") is False
+        assert converter.conversion_filter("/proj/coverage.xml") is False
+        assert converter.conversion_filter("/proj/htmlcov") is False
+        assert converter.conversion_filter("/proj/htmlcov/index.html") is False
+        assert converter.conversion_filter("/proj/.hypothesis") is False
+
+    def test_filters_pip_artifacts(self, converter):
+        """pip log/scratch files are filtered."""
+        assert converter.conversion_filter("/proj/pip-log.txt") is False
+        assert converter.conversion_filter("/proj/pip-delete-this-directory.txt") is False
+
+    def test_filters_os_noise(self, converter):
+        """Windows OS metadata files are filtered."""
+        assert converter.conversion_filter("/proj/Thumbs.db") is False
+        assert converter.conversion_filter("/proj/desktop.ini") is False
+
+    def test_filters_nested_ipynb_checkpoints(self, converter):
+        """Nested .ipynb_checkpoints directories are filtered."""
+        assert (
+            converter.conversion_filter("/proj/subdir/.ipynb_checkpoints/nb-checkpoint.ipynb")
+            is False
+        )
+
 
 class TestPrimeConverterConvert:
     """Integration tests for the convert method."""
@@ -405,6 +482,90 @@ x = 1
         # Defaults still filter
         assert not (output_dir / ".DS_Store").exists()
         assert not (output_dir / ".ipynb_checkpoints").exists()
+
+    def test_expanded_default_ignores_without_black_list_file(self, tmp_path):
+        """Comprehensive Python/IDE/venv/OS artifacts are excluded without black_list.pact."""
+        assignment_dir = tmp_path / "assignment"
+        assignment_dir.mkdir()
+
+        # Files that should survive
+        (assignment_dir / "main.py").write_text("code")
+        (assignment_dir / "environment.yml").write_text("name: test")
+
+        # Compiled / bytecode
+        (assignment_dir / "module.pyc").write_bytes(b"x")
+        (assignment_dir / "module.pyo").write_bytes(b"x")
+        (assignment_dir / "_ext.so").write_bytes(b"x")
+
+        # Virtual environments. macOS' default filesystem is case-insensitive,
+        # so we can't create both "env" and "ENV" side by side; the ENV regex
+        # is covered by the unit-level test_filters_virtual_environments.
+        for vname in (".venv", "venv", "env"):
+            d = assignment_dir / vname
+            d.mkdir()
+            (d / "ignored.py").write_text("x")
+
+        # Build / packaging artifacts
+        for bname in ("build", "dist", "wheels", "eggs", ".eggs", "pact.egg-info"):
+            d = assignment_dir / bname
+            d.mkdir()
+            (d / "ignored.py").write_text("x")
+        (assignment_dir / "MANIFEST").write_text("x")
+        (assignment_dir / "pact.egg").write_text("x")
+
+        # IDE / editor
+        for iname in (".idea", ".vscode"):
+            d = assignment_dir / iname
+            d.mkdir()
+            (d / "ignored.txt").write_text("x")
+        (assignment_dir / "main.py.swp").write_bytes(b"x")
+
+        # Linter / typecheck caches
+        for cname in (".mypy_cache", ".pytype", ".ruff_cache"):
+            (assignment_dir / cname).mkdir()
+        (assignment_dir / ".dmypy.json").write_text("{}")
+        (assignment_dir / "dmypy.json").write_text("{}")
+
+        # Test / coverage
+        for tname in (".pytest_cache", ".tox", ".nox", "htmlcov", ".hypothesis"):
+            (assignment_dir / tname).mkdir()
+        (assignment_dir / ".coverage").write_text("")
+        (assignment_dir / ".coverage.host.123").write_text("")
+        (assignment_dir / "coverage.xml").write_text("<coverage/>")
+
+        # pip
+        (assignment_dir / "pip-log.txt").write_text("")
+        (assignment_dir / "pip-delete-this-directory.txt").write_text("")
+
+        # OS noise
+        (assignment_dir / ".DS_Store").write_bytes(b"\x00")
+        (assignment_dir / "Thumbs.db").write_bytes(b"\x00")
+        (assignment_dir / "desktop.ini").write_text("")
+
+        # Nested ipynb_checkpoints
+        nested = assignment_dir / "src" / ".ipynb_checkpoints"
+        nested.mkdir(parents=True)
+        (nested / "nb-checkpoint.ipynb").write_text("{}")
+        (assignment_dir / "src" / "module.py").write_text("code")
+
+        converter = PrimeConverter()
+        converter.convert(str(assignment_dir))
+
+        output_dir = assignment_dir / GENERATED_LOCATION_NAME / assignment_dir.name
+
+        # Things that should ship
+        assert (output_dir / "main.py").exists()
+        assert (output_dir / "environment.yml").exists()
+        assert (output_dir / "src" / "module.py").exists()
+
+        # Nothing else should
+        present = {p.name for p in output_dir.iterdir()}
+        survivors = {"main.py", "environment.yml", "src", "create_submission_zip.py"}
+        unexpected = present - survivors
+        assert not unexpected, f"Unexpected files in student version: {unexpected}"
+
+        # Nested checkpoint dir excluded even though src/ is kept
+        assert not (output_dir / "src" / ".ipynb_checkpoints").exists()
 
     def test_existing_redundant_black_list_still_works(self, tmp_path):
         """A black_list.pact that redundantly lists default patterns still works."""

--- a/tests/unit_tests/test_codeblocks.py
+++ b/tests/unit_tests/test_codeblocks.py
@@ -1,0 +1,78 @@
+"""Unit tests for built-in codeblock instances in pact.convert.codeblocks."""
+from __future__ import annotations
+
+import json
+
+from pact.convert.codeblocks import (
+    CODEBLOCK_TYPES,
+    IPYNB_ANSWER,
+    KEY_ONLY,
+    STUDENT_CODE,
+)
+from pact.convert.masks import MASKTYPES
+from pact.convert.utils.file_converter import FileConverter
+
+
+class TestBuiltinCodeblockRegistry:
+    """The built-in codeblock instances are exported and registered."""
+
+    def test_ipynb_answer_registered(self):
+        assert IPYNB_ANSWER in CODEBLOCK_TYPES
+
+    def test_all_builtins_registered(self):
+        for block in (STUDENT_CODE, KEY_ONLY, IPYNB_ANSWER):
+            assert block in CODEBLOCK_TYPES
+
+    def test_ipynb_answer_triggers(self):
+        assert IPYNB_ANSWER.start_trigger_str == "IPYNB_ANSWER_START"
+        assert IPYNB_ANSWER.end_trigger_str == "IPYNB_ANSWER_END"
+        assert "YOUR ANSWER HERE" in IPYNB_ANSWER.replacement_str
+
+
+class TestIpynbAnswerConversion:
+    """End-to-end: IPYNB_ANSWER wraps instructor text in a markdown cell."""
+
+    def _converter(self):
+        return FileConverter(
+            codeblock_types=CODEBLOCK_TYPES, mask_types=MASKTYPES
+        )
+
+    def _notebook(self, source):
+        return {
+            "cells": [
+                {
+                    "cell_type": "markdown",
+                    "metadata": {},
+                    "source": source,
+                }
+            ],
+            "metadata": {},
+            "nbformat": 4,
+            "nbformat_minor": 5,
+        }
+
+    def test_ipynb_answer_replaces_instructor_text(self, tmp_path):
+        source = (
+            "**Q1.** Why is X important?\n"
+            "\n"
+            "IPYNB_ANSWER_START\n"
+            "Because X is the foundation of Y and unlocks Z.\n"
+            "IPYNB_ANSWER_END\n"
+        )
+        nb_path = tmp_path / "notebook.ipynb"
+        nb_path.write_text(json.dumps(self._notebook(source)))
+
+        out_dir = tmp_path / "out"
+        self._converter().convert_file(str(nb_path), str(out_dir))
+
+        converted = json.loads((out_dir / "notebook.ipynb").read_text())
+        cell_source = "".join(converted["cells"][0]["source"])
+
+        # The instructor text and trigger lines are gone
+        assert "Because X is the foundation" not in cell_source
+        assert "IPYNB_ANSWER_START" not in cell_source
+        assert "IPYNB_ANSWER_END" not in cell_source
+        # The placeholder is present
+        assert "YOUR ANSWER HERE" in cell_source
+        # The question prompt is preserved
+        assert "Why is X important?" in cell_source


### PR DESCRIPTION
## Summary

Closes #5 and closes #6.

- **#6 — `IPYNB_ANSWER` codeblock**: New built-in `CodeBlockType` wired into `CODEBLOCK_TYPES`. Authors wrap instructor-written answer text in a notebook markdown cell with `IPYNB_ANSWER_START` / `IPYNB_ANSWER_END`; the student version gets a green `YOUR ANSWER HERE` placeholder.
- **#5 — comprehensive `DEFAULT_BLACK_LIST`**: Expanded from 3 patterns to cover Python virtual envs, build / packaging artifacts, compiled Python, IDE metadata, linter and type-checker caches, test / coverage artifacts, pip scratch files, and Windows OS noise. Directory-style patterns use `(^|/)name($|/)` so `venv` won't accidentally match `prevention.py`. Per-assignment `black_list.pact` semantics are unchanged — user patterns still merge with the defaults.
- Removed the now-redundant `.pyc` substring check in `conversion_filter` (covered by `\.py[cod]$`).

## Test plan

- [x] `python -m pytest tests/ -v` → 165 passed
- [x] New unit tests in `tests/unit_tests/test_codeblocks.py` cover `IPYNB_ANSWER` registry membership and notebook conversion.
- [x] New unit tests in `tests/integration_tests/test_prime_converter.py` cover each new black-list category (virtual envs, build artifacts, compiled Python, IDE metadata, linter caches, test/coverage artifacts, pip artifacts, OS noise, nested checkpoints).
- [x] New integration test creates one of each ignored artifact in a fixture directory, runs conversion with no `black_list.pact`, and asserts none of them appear in `STUDENT_VERSION/`.
- [x] Verified substring collisions are NOT filtered (`prevention.py`, `environment.yml` still ship).